### PR TITLE
rust_release: Checkout as token user

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.WF_GITHUB_TOKEN }} # <-- PAT secret name
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
As documented in the action

```
Once you generated your token, save it in the secrets, and pass it to both the actions/checkout and release-plz steps
```

https://release-plz.ieni.dev/docs/github/token

I think this will fix Actions not being triggered properly